### PR TITLE
Work around multiple warnings

### DIFF
--- a/molecular/gfx/Material.cpp
+++ b/molecular/gfx/Material.cpp
@@ -58,7 +58,6 @@ void Material::SetTexture(Hash hash, Hash textureFileName)
 
 void Material::Bind(int lodLevel)
 {
-	assert(this);
 	assert(!mBound);
 	for(auto& uniform: mUniforms)
 	{

--- a/molecular/gfx/NmbMeshDataSource.cpp
+++ b/molecular/gfx/NmbMeshDataSource.cpp
@@ -100,7 +100,7 @@ NmbMeshDataSource::NmbMeshDataSource(NmbFile& file, const std::string& submesh) 
 	}
 }
 
-int NmbMeshDataSource::PrepareVertexData(LayoutHint layout)
+int NmbMeshDataSource::PrepareVertexData(LayoutHint /*layout*/)
 {
 	return mVertexBuffers.size();
 }

--- a/molecular/gfx/RenderFunction.h
+++ b/molecular/gfx/RenderFunction.h
@@ -74,7 +74,7 @@ public:
 	virtual molecular::util::AxisAlignedBox GetBounds() const = 0;
 	virtual bool BoundsChangedSince(int /*framecounter*/) const {return false;}
 
-	virtual void Set(Hash variable, bool value) {throw std::runtime_error("This RenderFunction does not have bool parameters");}
+	virtual void Set(Hash /*variable*/, bool /*value*/) {throw std::runtime_error("This RenderFunction does not have bool parameters");}
 
 protected:
 	/// Convenience shortcut to a variable pointer from the dynamic scope

--- a/molecular/gfx/TetrahedronInterpolation.cpp
+++ b/molecular/gfx/TetrahedronInterpolation.cpp
@@ -54,7 +54,7 @@ Matrix<3, 9> TetrahedronInterpolation::GetShCoefficients(const Vector3& position
 		return kZeros;
 	Vector4 weights = GetLightProbeInterpolationWeights(position, tetIndex);
 	const TetrahedronSpaceFile* file = static_cast<const TetrahedronSpaceFile*>(mFileData.GetData());
-	if (tetIndex < 0 || tetIndex >= file->numTetrahedrons)
+	if (tetIndex < 0 || static_cast<uint32_t>(tetIndex) >= file->numTetrahedrons)
 		return kZeros;
 	auto& tet = file->tetrahedra[tetIndex];
 	auto verts = file->GetVertices();
@@ -77,7 +77,7 @@ void TetrahedronInterpolation::GetTetrahedronCorners(int tetIndex, Vector3 outCo
 	}
 
 	const TetrahedronSpaceFile* file = static_cast<const TetrahedronSpaceFile*>(mFileData.GetData());
-	if(tetIndex >= 0 && tetIndex < file->numTetrahedrons)
+	if(tetIndex >= 0 && tetIndex < static_cast<int>(file->numTetrahedrons))
 	{
 		auto& tet = file->tetrahedra[tetIndex];
 		auto verts = file->GetVertices();

--- a/molecular/gfx/TextureManager.h
+++ b/molecular/gfx/TextureManager.h
@@ -117,7 +117,7 @@ void TextureLoader<TRenderManager>::StartLoad(TextureManager::Asset& asset, unsi
 }
 
 template<class TRenderManager>
-void TextureLoader<TRenderManager>::Unload(RenderCmdSink::Texture*& asset, unsigned int minLevel, unsigned int maxLevel)
+void TextureLoader<TRenderManager>::Unload(RenderCmdSink::Texture*& /*asset*/, unsigned int /*minLevel*/, unsigned int /*maxLevel*/)
 {
 	// TODO
 }
@@ -149,7 +149,7 @@ void TextureLoader<TRenderManager>::StoreTexture(TextureManager::Asset& target, 
 }
 
 template<class TRenderManager>
-void TextureLoader<TRenderManager>::StoreTgaTexture(TextureManager::Asset& target, Blob& blob, unsigned int minLevel, unsigned int maxLevel)
+void TextureLoader<TRenderManager>::StoreTgaTexture(TextureManager::Asset& target, Blob& blob, unsigned int /*minLevel*/, unsigned int /*maxLevel*/)
 {
 	TgaFile2 file(blob.GetData(), blob.GetSize());
 	if(file.IsUpsideDown())

--- a/molecular/gfx/functions/FlatScene.cpp
+++ b/molecular/gfx/functions/FlatScene.cpp
@@ -58,7 +58,7 @@ util::AxisAlignedBox FlatScene::GetBounds() const
 	return util::AxisAlignedBox();
 }
 
-bool FlatScene::BoundsChangedSince(int framecounter) const
+bool FlatScene::BoundsChangedSince(int /*framecounter*/) const
 {
 	// TODO
 	return false;

--- a/molecular/gfx/functions/ParticleSystem.cpp
+++ b/molecular/gfx/functions/ParticleSystem.cpp
@@ -97,7 +97,6 @@ void ParticleSystem::InitProgram(RenderCmdSink::Program* program, const std::str
 
 void ParticleSystem::InitParticleBuffers()
 {
-	assert(this);
 	std::vector<Particle> p(kMaxParticles); // Do not use array on stack!
 	memset(p.data(), 0, kMaxParticles * sizeof(Particle));
 
@@ -216,7 +215,7 @@ void ParticleSystem::DrawParticles()
 
 void ParticleSystem::MoveEmitters()
 {
-	for(int n = 0; n < mEmittersCount; n++)
+	for(unsigned n = 0; n < mEmittersCount; n++)
 	{
 		Particle& p = mEmitters[n];
 		if(!mParams.freezeEmitters)
@@ -245,7 +244,7 @@ void ParticleSystem::SeedEmitters(unsigned int num)
 	mEmittersCount = std::min(num, +kMaxEmitters);
 
 	memset(mEmitters, 0, mEmittersCount * sizeof(Particle));
-	for(int n = 0; n < mEmittersCount; n++)
+	for(unsigned n = 0; n < mEmittersCount; n++)
 	{
 		mEmitters[n].color[0] = rand() & 255;
 		mEmitters[n].color[1] = rand() & 255;

--- a/molecular/gfx/opengl/GlCommandSinkProgram.cpp
+++ b/molecular/gfx/opengl/GlCommandSinkProgram.cpp
@@ -95,7 +95,7 @@ void GlCommandSink::Program::SetUniform(Hash key, const Texture* const* textures
 			break;
 	}
 
-	for(size_t i = 0; i < count && i < mTextureUnits.size() - unit; ++i)
+	for(size_t i = 0; i < static_cast<size_t>(count) && i < mTextureUnits.size() - unit; ++i)
 	{
 		if(textures[i] && mTextureUnits[unit + i] == key)
 		{

--- a/molecular/gfx/opengl/PixelFormatConversion.cpp
+++ b/molecular/gfx/opengl/PixelFormatConversion.cpp
@@ -181,7 +181,7 @@ uint32_t ToGlInternalFormat(PixelFormat format)
 	}
 }
 
-PixelFormat ToPixelFormat(uint32_t glType, uint32_t glFormat, uint32_t glInternalFormat)
+PixelFormat ToPixelFormat(uint32_t /*glType*/, uint32_t /*glFormat*/, uint32_t glInternalFormat)
 {
 	switch(glInternalFormat)
 	{

--- a/molecular/util/DdsFile.h
+++ b/molecular/util/DdsFile.h
@@ -37,7 +37,7 @@ namespace molecular
 
 /// Four character code string literal
 /** Little Endian. */
-constexpr uint32_t operator"" _4CC(const char* str, size_t length)
+constexpr uint32_t operator"" _4CC(const char* str, size_t /*length*/)
 {
 //	static_assert(length == 4, "Only four characters allowed");
 	return  uint32_t(str[0]) |

--- a/molecular/util/FontAtlasDescriptionFile.h
+++ b/molecular/util/FontAtlasDescriptionFile.h
@@ -101,9 +101,10 @@ struct FontAtlasDescriptionFile
 
 	const GlyphInfo* GetGlyph(char charcode) const
 	{
-		if(asciiOffsets[charcode] < sizeof(FontAtlasDescriptionFile))
+		uint8_t code = static_cast<uint8_t>(charcode);
+		if(asciiOffsets[code] < sizeof(FontAtlasDescriptionFile))
 			return nullptr;
-		return reinterpret_cast<const GlyphInfo*>(reinterpret_cast<const uint8_t*>(this) + asciiOffsets[charcode]);
+		return reinterpret_cast<const GlyphInfo*>(reinterpret_cast<const uint8_t*>(this) + asciiOffsets[code]);
 	}
 };
 

--- a/molecular/util/KtxFile.cpp
+++ b/molecular/util/KtxFile.cpp
@@ -74,9 +74,9 @@ std::pair<const void*, std::size_t> KtxFile::GetImageData(int mipmapLevel, int f
 {
 	const unsigned int numberOfArrayElements = std::max(1u, GetNumberOfArrayElements());
 	const unsigned int numberOfFaces = GetNumberOfFaces();
-	assert(mipmapLevel == 0 || mipmapLevel < GetNumberOfMipmapLevels());
-	assert(face == 0 || face < numberOfFaces);
-	assert(arrayElement < numberOfArrayElements);
+	assert(mipmapLevel == 0 || static_cast<unsigned>(mipmapLevel) < GetNumberOfMipmapLevels());
+	assert(face == 0 || static_cast<unsigned>(face) < numberOfFaces);
+	assert(static_cast<unsigned>(arrayElement) < numberOfArrayElements);
 
 	size_t singleImageSize = mMipLevels[mipmapLevel].imageSize;
 	if(numberOfFaces != 6 || numberOfArrayElements != 0)

--- a/molecular/util/MtlFile.cpp
+++ b/molecular/util/MtlFile.cpp
@@ -72,10 +72,10 @@ MtlFile::MtlFile(const char* begin, const char* end)
 	using Kd = Keyword2<'K', 'd'>;
 	using Ks = Keyword2<'K', 's'>;
 	using Illum = Keyword5<'i', 'l', 'l', 'u', 'm'>;
-	using MapKa = Keyword6<'m', 'a', 'p', '_', 'K', 'a'>;
-	using MapKd = Keyword6<'m', 'a', 'p', '_', 'K', 'd'>;
-	using MapKs = Keyword6<'m', 'a', 'p', '_', 'K', 's'>;
-	using MapNs = Keyword6<'m', 'a', 'p', '_', 'N', 's'>;
+//	using MapKa = Keyword6<'m', 'a', 'p', '_', 'K', 'a'>;
+//	using MapKd = Keyword6<'m', 'a', 'p', '_', 'K', 'd'>;
+//	using MapKs = Keyword6<'m', 'a', 'p', '_', 'K', 's'>;
+//	using MapNs = Keyword6<'m', 'a', 'p', '_', 'N', 's'>;
 	using TrD = Alternation<Keyword2<'T', 'r'>, Char<'d'>>;
 
 	using NewmtlDecl = Concatenation<Newmtl, Whitespace, Action<String, kNewmtlValue>>;


### PR DESCRIPTION
Multiple warning are present when compiling with `-Wall`.
These fixes all warning which are generated when compiling the `molecular-example-humanhead` target.