### PR TITLE
Add CharacterAnimation to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ configure_file(molecular/Config.h.in molecular/Config.h)
 
 add_library(molecular-gfx
 	molecular/gfx/AssetManager.h
+	molecular/gfx/CharacterAnimation.cpp
+	molecular/gfx/CharacterAnimation.h
 	molecular/gfx/DefaultProgramData.cpp
 	molecular/gfx/DefaultProgramData.h
 	molecular/gfx/DrawText.cpp


### PR DESCRIPTION
These files are missing from CMake and cause linking issues with some build configurations.