### PR TITLE
ViewSetup: Don't set target to NULL

### DIFF
--- a/molecular/gfx/functions/ViewSetup.cpp
+++ b/molecular/gfx/functions/ViewSetup.cpp
@@ -55,7 +55,6 @@ void ViewSetup::Execute()
 		**viewMatrix = defaultRotation * (mCamera * mRenderContext.GetHeadToEyeTransform(eye)).Inverse();
 
 		mRenderer.SetBaseTarget(viewport, renderTarget);
-		mRenderer.SetTarget(nullptr);
 		mRenderer.Clear(true, true);
 
 		if(mRenderContext.HasProjectionMatrix(eye))


### PR DESCRIPTION
This interferes with some use cases where the user needs to bind the FBO and then have this function render to this FBO. I've tested this with the head example and it sill works.