### PR TITLE
Avoid using illegal reinterpret cast on floats

### DIFF
--- a/molecular/util/StreamBase.cpp
+++ b/molecular/util/StreamBase.cpp
@@ -46,12 +46,12 @@ void WriteStreamBase::Write(const int value, const int precision)
 
 void WriteStreamBase::Write(const float value)
 {
-	Write(*reinterpret_cast<const uint32_t*>(&value));
+	Write(&value, 4);
 }
 
 void WriteStreamBase::Write(const double value)
 {
-	Write(*reinterpret_cast<const uint64_t*>(&value));
+	Write(&value, 8);
 }
 
 void WriteStreamBase::Write(const bool value)


### PR DESCRIPTION
This generates warnings on both clang and gcc:

Clang:
```
/home/ecikovic/localstorage/Workspace/molecular/molecular-gfx/molecular/util/StreamBase.cpp:49: warning: dereference of type 'const uint32_t *' (aka 'const unsigned int *') that was reinterpret_cast from type 'const float *' has undefined behavior
```

GCC:

```
dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing] Write(*reinterpret_cast(&value));
```