### PR TITLE
Various fixes

### DIFF
--- a/molecular/gfx/MeshLoader.h
+++ b/molecular/gfx/MeshLoader.h
@@ -122,6 +122,8 @@ void MeshLoader<TRenderManager>::StoreMesh(MeshManager::Asset& destination, Blob
 		StoreCompiledMesh(destination, blob);
 	else if(FileTypeIdentification::IsNmb(blob.GetData(), blob.GetSize()))
 		StoreNmb(destination, blob);
+	else
+		LOG(WARNING) << "MeshLoader: Unknown mesh file type";
 }
 
 template<class TRenderManager>

--- a/molecular/gfx/functions/ApplyTextures.cpp
+++ b/molecular/gfx/functions/ApplyTextures.cpp
@@ -53,7 +53,10 @@ void ApplyTextures::SetParameter(Hash variable, RenderCmdSink::Texture::Paramete
 void ApplyTextures::SetTextureUniforms(TextureMap::const_iterator it)
 {
 	if(it == mTextures.end())
-		mCallee->Execute();
+	{
+		if(mCallee)
+			mCallee->Execute();
+	}
 	else
 	{
 		Binding<Uniform<RenderCmdSink::Texture*> > texture(it->first, this);

--- a/molecular/gfx/functions/DrawMeshData.cpp
+++ b/molecular/gfx/functions/DrawMeshData.cpp
@@ -178,7 +178,10 @@ void DrawMeshData::Draw(Mesh& mesh)
 	}
 
 	PrepareProgram();
-	mRenderer.Draw(mIndexBuffers.at(mesh.info.buffer), mesh.info);
+	if(mIndexBuffers.size() < (mesh.info.buffer + 1))
+		mRenderer.Draw(mesh.info.mode, mesh.info.count);
+	else
+		mRenderer.Draw(mIndexBuffers.at(mesh.info.buffer), mesh.info);
 
 	if(add || mix)
 	{

--- a/molecular/gfx/functions/DrawMeshData.cpp
+++ b/molecular/gfx/functions/DrawMeshData.cpp
@@ -178,7 +178,7 @@ void DrawMeshData::Draw(Mesh& mesh)
 	}
 
 	PrepareProgram();
-	if(mIndexBuffers.size() < (mesh.info.buffer + 1))
+	if(mIndexBuffers.empty())
 		mRenderer.Draw(mesh.info.mode, mesh.info.count);
 	else
 		mRenderer.Draw(mIndexBuffers.at(mesh.info.buffer), mesh.info);

--- a/molecular/gfx/functions/ViewSetup.cpp
+++ b/molecular/gfx/functions/ViewSetup.cpp
@@ -51,8 +51,7 @@ void ViewSetup::Execute()
 		auto renderTarget = mRenderContext.GetRenderTarget(eye);
 		**viewportSize = Vector2(viewport[2], viewport[3]);
 
-		static const Matrix4 defaultRotation = Matrix4::RotationX(-0.5f * Math::kPi_f) * Matrix4::RotationZ(0.5f * Math::kPi_f);
-		**viewMatrix = defaultRotation * (mCamera * mRenderContext.GetHeadToEyeTransform(eye)).Inverse();
+		**viewMatrix = (mCamera * mRenderContext.GetHeadToEyeTransform(eye)).Inverse();
 
 		mRenderer.SetBaseTarget(viewport, renderTarget);
 		mRenderer.Clear(true, true);


### PR DESCRIPTION
- Check for callee before calling execture
- Add support for meshes without index buffers
- Remove default rotation matrix from `ViewSetup`
- Warn on storing of unsupported mesh types