### PR TITLE
Fix missing namespaces in some files

### DIFF
--- a/molecular/gfx/MeshLoader.h
+++ b/molecular/gfx/MeshLoader.h
@@ -129,7 +129,7 @@ void MeshLoader<TRenderManager>::StoreMesh(MeshManager::Asset& destination, Blob
 template<class TRenderManager>
 void MeshLoader<TRenderManager>::StoreCompiledMesh(MeshManager::Asset& destination, Blob& blob)
 {
-	const MeshFile& file = *static_cast<const MeshFile*>(blob.GetData());
+	const meshfile::MeshFile& file = *static_cast<const meshfile::MeshFile*>(blob.GetData());
 	try
 	{
 		destination.GetAsset()->Load(file);

--- a/molecular/gfx/RenderContext.h
+++ b/molecular/gfx/RenderContext.h
@@ -42,11 +42,11 @@ public:
 	virtual ~RenderContext() = default;
 
 	virtual int GetNumEyes() {return 1;}
-	virtual IntVector4 GetViewport(int eye) = 0;
+	virtual util::IntVector4 GetViewport(int eye) = 0;
 	virtual intptr_t GetRenderTarget(int eye) {assert(eye == 0); return 0;}
-	virtual Matrix4 GetHeadToEyeTransform(int eye) {assert(eye == 0); return Matrix4::Identity();}
+	virtual util::Matrix4 GetHeadToEyeTransform(int eye) {assert(eye == 0); return util::Matrix4::Identity();}
 	virtual bool HasProjectionMatrix(int eye) {assert(eye == 0); return false;}
-	virtual Matrix4 GetProjectionMatrix(int /*eye*/) {assert(false); return Matrix4::Identity();}
+	virtual util::Matrix4 GetProjectionMatrix(int /*eye*/) {assert(false); return util::Matrix4::Identity();}
 };
 
 }

--- a/molecular/gfx/RenderManager.h
+++ b/molecular/gfx/RenderManager.h
@@ -86,7 +86,7 @@ public:
 	FileServer& GetFileServer() {return mFileServer;}
 	TextureManager& GetTextureManager() {return mTextureManager;}
 	MeshManager& GetMeshManager() {return mMeshManager;}
-	ProgramGenerator& GetProgramGenerator() {return mProgramGenerator;}
+	programgenerator::ProgramGenerator& GetProgramGenerator() {return mProgramGenerator;}
 	ProgramProvider& GetProgramProvider() {return mProgramProvider;}
 	MaterialManager& GetMaterialManager() {return mMaterialManager;}
 
@@ -111,7 +111,7 @@ private:
 	MeshManager mMeshManager;
 	MaterialManager mMaterialManager;
 
-	ProgramGenerator mProgramGenerator;
+	programgenerator::ProgramGenerator mProgramGenerator;
 	ProgramProvider mProgramProvider;
 
 	Blob mMeshBoundsCollectionFileData;
@@ -151,7 +151,7 @@ bool RenderManagerT<TFileServer, TTaskQueue>::LoadProgramFile(const Blob& fileCo
 	try
 	{
 		char* fileBegin =  const_cast<char*>(static_cast<const char*>(fileContents.GetData()));
-		ProgramFile progFile(fileBegin, fileBegin + fileContents.GetSize());
+		programgenerator::ProgramFile progFile(fileBegin, fileBegin + fileContents.GetSize());
 
 		for(auto& it: progFile.GetVariables())
 		{

--- a/molecular/gfx/glfw/GlfwContext.cpp
+++ b/molecular/gfx/glfw/GlfwContext.cpp
@@ -38,7 +38,7 @@ GlfwContext::GlfwContext(GLFWwindow* window) :
 
 }
 
-IntVector4 GlfwContext::GetViewport(int eye)
+util::IntVector4 GlfwContext::GetViewport(int eye)
 {
 	assert(eye == 0);
 	int x = 0;

--- a/molecular/gfx/glfw/GlfwContext.h
+++ b/molecular/gfx/glfw/GlfwContext.h
@@ -43,7 +43,7 @@ public:
 	/** Throws exceptions on failure. */
 	GlfwContext(GLFWwindow* window);
 
-	IntVector4 GetViewport(int eye) override;
+	util::IntVector4 GetViewport(int eye) override;
 
 private:
 	GLFWwindow* mWindow = nullptr;

--- a/molecular/gfx/glfw/GlfwFileLoader.h
+++ b/molecular/gfx/glfw/GlfwFileLoader.h
@@ -33,7 +33,7 @@ namespace molecular
 namespace gfx
 {
 /// Selects file loader, depending on OS
-using GlfwFileLoader = GcdAsyncFileLoader;
+using GlfwFileLoader = util::GcdAsyncFileLoader;
 }
 }
 #else
@@ -43,7 +43,7 @@ namespace molecular
 namespace gfx
 {
 /// Selects file loader, depending on OS
-using GlfwFileLoader = DummyFileLoader;
+using GlfwFileLoader = util::DummyFileLoader;
 }
 }
 #endif


### PR DESCRIPTION
The example target wasn't building due to namespaces missing in some files.