### PR TITLE
Fix some drawing functions

### DIFF
--- a/molecular/gfx/functions/DrawSkyDome.h
+++ b/molecular/gfx/functions/DrawSkyDome.h
@@ -108,7 +108,7 @@ void DrawSkyDome<TRenderManager>::HandleExecute(Scope& scope)
 			}
 		}
 		mVertexBuffer = mRenderer.CreateVertexBuffer();
-		mVertexBuffer->Store(vertexData.data(), 5 *  vertexData.size());
+		mVertexBuffer->Store(vertexData.data(), 5 *  vertexData.size() * sizeof (float));
 		mPositionInfo.components = 3;
 		mPositionInfo.stride = 5 * sizeof(float);
 		mPositionInfo.type = VertexAttributeInfo::kFloat;
@@ -153,7 +153,7 @@ void DrawSkyDome<TRenderManager>::HandleExecute(Scope& scope)
 
 	if(mTexture)
 		scope.Set("diffuseTexture"_H, Uniform<RenderCmdSink::Texture*>(mTexture->Use()));
-	mRenderer.SetDepthState(true, false, RenderCmdSink::kEqual);
+	mRenderer.SetDepthState(true, false, RenderCmdSink::kLessOrEqual);
 	PrepareProgram(scope);
 	mRenderer.Draw(mIndexBuffer, mIndexInfo);
 	mRenderer.SetDepthState(true, true);


### PR DESCRIPTION
- Fixed vertex order for triangle primitives in DrawTerrain to be aligned with GL_BACK
culling mode
- Fixed vertexbuffer deployment for the DrawSkyDome. Depth function is
set to GL_LEQUAL.